### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/matcharr/bot-discord/security/code-scanning/3](https://github.com/matcharr/bot-discord/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The block can be added at the root level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job (`test`), either location is acceptable, but the root level is preferred for clarity and future extensibility. The minimal required permission for this workflow is `contents: read`, which allows the workflow to check out code and upload coverage reports, but does not allow writing to the repository. Add the following block after the workflow `name` and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
